### PR TITLE
update build with headless phantomjs ghostdriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/node_modules
 **/build
-
-**/results
+**/results/**
 !**/results/**/*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/node_modules
-**/results
 **/build
+
+**/results
+!**/results/**/*.html

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -10,14 +10,15 @@
 
   "selenium": {
     "start_process": true,
-    "server_path": "./tests/drivers/sel-serv.jar",
+    "server_path": "./tests/drivers/selenium-server-standalone-2.47.1.jar",
     "log_path": "./tests/results/logs/",
     "host": "127.0.0.1",
     "port": 4444,
     "cli_args": {
       "webdriver.chrome.driver": "./tests/drivers/chromedriver.exe",
       "webdriver.ie.driver": "./tests/drivers/IEDriverServer32.exe",
-      "webdriver.firefox.profile": ""
+      "webdriver.firefox.profile": "",
+      "phantomjs.binary.path": "./tests/drivers/phantomjs.exe"
     }
   },
 
@@ -43,6 +44,14 @@
         "chromeOptions": {
           "args": ["--window-size=1200,1200", "--window-position=0,-9900", "--test-type"]
         }
+      }
+    },
+
+    "phantomjs": {
+      "desiredCapabilities": {
+        "browserName" : "phantomjs",
+        "javascriptEnabled" : true,
+        "acceptSslCerts" : true
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -25,34 +25,31 @@
     "clean:tests": "del .\\tests\\build /Q /S",
     "clean:lib": "del .\\lib\\build /Q /S",
     "clean": "npm run clean:results&& npm run clean:tests&& npm run clean:lib",
-
     "compile:stylus:lib": "stylus -o lib/build lib/combo.styl",
     "compile:coffee:lib": "coffee -o lib/build -c lib/",
     "compile:coffee:tests": "coffee -o tests/build -c tests/",
     "compile:lib": "npm run compile:stylus:lib& npm run compile:coffee:lib",
     "compile:tests": "npm run compile:coffee:tests",
     "compile": "npm run compile:lib& npm run compile:tests",
-
     "watch:stylus:lib": "title w:stylus:lib& stylus -o lib/build lib/combo.styl -w",
     "watch:coffee:lib": "title w:coffee:lib& coffee -o lib/build -wc lib/",
     "watch:coffee:tests": "title: w:coffee:tests& coffee -o tests/build -wc tests/",
     "watch:lib": "start npm run watch:stylus:lib& start npm run watch:coffee:lib",
     "watch:tests": "start npm run watch:coffee:tests",
     "watch": "npm run watch:lib& npm run watch:tests",
-
     "test:sanity": "title nightwatch& nightwatch -o tests/results/reports/sanity/ -g sanity",
     "test:dev": "title nightwatch& nightwatch -o tests/results/reports/dev/ -s fails",
     "test:chrome": "title nightwatch& nightwatch -o tests/results/reports/chrome/ -e chrome -s fails",
     "test:ie": "title nightwatch& nightwatch -o tests/results/reports/ie/ -e ie -s fails",
     "test:firefox": "title nightwatch& nightwatch -o tests/results/reports/firefox/ -e firefox -s fails",
-
+    "test:phantomjs": "title nightwatch& nightwatch -o tests/results/reports/phantomjs/ -e phantomjs -s fails",
     "report:sanity": "nightwatch-html-reporter -d tests/results/reports/sanity -o report_sanity.html",
     "report:dev": "nightwatch-html-reporter -d tests/results/reports/dev -o report_dev.html",
     "report:chrome": "nightwatch-html-reporter -d tests/results/reports/chrome -o report_chrome.html",
     "report:ie": "nightwatch-html-reporter -d tests/results/reports/ie -o report_ie.html",
     "report:firefox": "nightwatch-html-reporter -d tests/results/reports/firefox -o report_firefox.html",
+    "report:phantomjs": "nightwatch-html-reporter -d tests/results/reports/phantomjs -o report_phantomjs.html",
     "report": "npm run report:chrome&& npm run report:ie&& npm run report:firefox",
-
     "setup": "npm run clean& npm run compile",
     "test": "npm run test:chrome&& npm run test:ie&& npm run test:firefox&& npm run report",
     "start": "npm run clean& npm run compile&& npm run watch&& start ./tests/index.html"
@@ -77,8 +74,8 @@
   },
   "devDependencies": {
     "coffee-script": "^1.8.0",
-    "nightwatch": "^0.5.36",
-    "nightwatch-html-reporter": "^0.2.11",
+    "nightwatch": "^0.8.3",
+    "nightwatch-html-reporter": "^0.2.12",
     "stylus": "^0.49.3",
     "watch": "^0.13.0"
   }


### PR DESCRIPTION
Tests ran 6 minutes versus Chrome in 5 minutes, and 7 additional tests failed (visibility stuff I think). It has the great advantage to be runnable in a way that leaves the computer accessible without interfering with the tests but is neither faster nor comparable wrt. browser support (either ie, firefox or chrome).
