### PR TITLE
"@input.one 'keypress', (keypress) => keypress.preventDefault()" trun…

### DIFF
--- a/lib/build/combo.js
+++ b/lib/build/combo.js
@@ -437,11 +437,6 @@
               return event.preventDefault();
             case this.key.ENTER:
             case this.key.NUMPAD_ENTER:
-              this.input.one('keypress', (function(_this) {
-                return function(keypress) {
-                  return keypress.preventDefault();
-                };
-              })(this));
               if (this.activeLi) {
                 this.selectLi(this.activeLi);
               }

--- a/lib/combo.coffee
+++ b/lib/combo.coffee
@@ -297,8 +297,6 @@
             @moveNext()
             event.preventDefault()
           when @key.ENTER, @key.NUMPAD_ENTER
-            # Opera still allows the keypress to occur which causes forms to submit
-            @input.one 'keypress', (keypress) => keypress.preventDefault()
             @selectLi @activeLi if @activeLi
             event.preventDefault()
             event.stopPropagation()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "combojs",
-  "version": "v0.1.56",
+  "version": "v0.1.57",
   "description": "A combobox for intelligent, responsive search and filtering.",
   "author": "Asger Hallas",
   "contributors": [

--- a/tests/commands/newComboElement.coffee
+++ b/tests/commands/newComboElement.coffee
@@ -19,16 +19,16 @@ module.exports.command = (ns, data=[], options={}, shouldFail=false) ->
 #====================================================
 # SUBROUTINES
 #====================================================
-newComboElement = (ns, data, options) ->
+newComboElement = (ns, data, options={}) ->
   data = JSON.parse(data)
   options = JSON.parse(options)
   
   # functions are not stringified by JSON.stringify
   # must pass the function as a string instead
-  if (options.displayField.startsWith("function") || options.displayField.startsWith("("))
+  if (options.displayField?.startsWith("function") || options.displayField?.startsWith("("))
     options.displayField = eval(options.displayField)
 
-  if (options.titleField.startsWith("function") ||options.titleField.startsWith("("))
+  if (options.titleField?.startsWith("function") ||options.titleField?.startsWith("("))
     options.titleField = eval(options.titleField)
 
   container = $("<div id='#{ns}'>")

--- a/tests/tests/item_selection/first letter does not get truncated after 'enterpress'.coffee
+++ b/tests/tests/item_selection/first letter does not get truncated after 'enterpress'.coffee
@@ -1,0 +1,15 @@
+require('../../testutils.js').plug_macros()
+
+ns = ns_1275
+
+module.exports =
+  "first letter does not get truncated after 'enterpress'": (browser) ->
+    browser
+      .setupCombo()
+      .click(ns + combo_input)
+      .setValue(ns + combo_input, browser.Keys["DOWN_ARROW"])
+      .setValue(ns + combo_input, browser.Keys["DOWN_ARROW"])     
+      .setValue(ns + combo_input, browser.Keys["ENTER"])
+      .setValue(ns+combo_input, "first")
+      .assert.value(ns + combo_input, "my special number is 0.621first")
+      .end()


### PR DESCRIPTION
"@input.one 'keypress', (keypress) => keypress.preventDefault()" truncated first letter after an item select with "enterpress".

This line was decided to be removed as Opera was not of an importance.
If Opera needs to be supported properly in the future a fix for this is needed.
